### PR TITLE
+improved resource path handling

### DIFF
--- a/src/http/Url.ts
+++ b/src/http/Url.ts
@@ -1,0 +1,41 @@
+import { QueryStringBuilder, QueryComponent } from "../odata/QueryStringBuilder";
+
+export class Url {
+    private protocol: string;
+    private urlBase: string;
+    private pathname: string;
+    private search: QueryStringBuilder
+
+    constructor(url: string) {
+        this.search = new QueryStringBuilder();
+
+        this.parse(url);
+    }
+
+    public build(): string {
+        return `${this.protocol}//${this.urlBase}${this.pathname}${this.search.build()}`;
+    }
+
+    public addPath(path: string) {
+        if (this.pathname.endsWith("/")) {
+            this.pathname = this.pathname.substring(0, this.pathname.length - 1);
+        }
+        this.pathname += `/${path}`;
+    }
+
+    private parse(url: string) {
+        const parser = document.createElement("a");
+        parser.href = url;
+
+        this.protocol = parser.protocol;
+        this.urlBase = parser.host;
+        this.pathname = parser.pathname;
+        parser.search.replace("?", "").split("&").forEach(param => {
+            const splitParam = param.split("=");
+            if (splitParam.length > 1) {
+                this.search.addQuery(splitParam[0], splitParam[1]);
+                this.search[splitParam[0]] = splitParam[1]
+            }
+        });
+    }
+}

--- a/src/odata/OData.ts
+++ b/src/odata/OData.ts
@@ -3,6 +3,7 @@ import { ODataQueryOption, CRLF } from "./ODataConstants";
 import { HttpRequestBuilder } from "../http/HttpRequestBuilder";
 import { IHttpHeader } from "../http/HttpHeader";
 import { QueryStringBuilder } from "./QueryStringBuilder";
+import { Url } from "../http/Url";
 
 export interface IODataOptions {
     endpoint: string;
@@ -12,12 +13,20 @@ export interface IODataOptions {
 
 export class OData {
     private config: IODataOptions;
+    private url: Url;
     private request: QueryStringBuilder;
     private data: string;
 
     constructor(config?: IODataOptions) {
         this.config = config;
         this.request = new QueryStringBuilder();
+
+        this.url = new Url(config.endpoint);
+    }
+
+    resource(resource: string): OData {
+        this.url.addPath(resource);
+        return this;
     }
 
     setVerb(verb: HttpMethod): OData {
@@ -103,7 +112,7 @@ export class OData {
             });
     }
 
-    private buildQuery() {
-        return this.config.endpoint + this.request.build();
+    buildQuery() {
+        return this.url.build() + this.request.build();
     }
 }

--- a/src/odata/QueryStringBuilder.ts
+++ b/src/odata/QueryStringBuilder.ts
@@ -29,7 +29,7 @@ export class QueryStringBuilder {
         }
     }
 
-    addQuery(name: ODataQueryOption,
+    addQuery(name: string,
              value: string) {
         this.queryList.push(new QueryComponent(name, value));
     }

--- a/tests/http/Url.spec.ts
+++ b/tests/http/Url.spec.ts
@@ -1,0 +1,60 @@
+import { Url } from "../../src/http/Url";
+
+describe("Url", () => {
+    describe("constructor", () => {
+        it("should not throw given valid URL", () => {
+            [
+                "",
+                "http://coveo.crm.dynamics.com"
+            ].forEach(url => {
+                expect(() => new Url(url)).not.toThrow();
+            });
+        });
+    });
+
+    describe("build", () => {
+        it("should build URLs correctly", () => {
+            [
+                { inputString: "http://coveo.crm.dynamics.com", expectedUrl: "http://coveo.crm.dynamics.com/" },
+                { inputString: "https://coveo.crm.dynamics.com", expectedUrl: "https://coveo.crm.dynamics.com/" },
+                { inputString: "http://coveo.crm.dynamics.com/a", expectedUrl: "http://coveo.crm.dynamics.com/a" },
+                { inputString: "http://coveo.crm.dynamics.com/a/bsd", expectedUrl: "http://coveo.crm.dynamics.com/a/bsd" },
+                { inputString: "http://coveo.crm.dynamics.com?", expectedUrl: "http://coveo.crm.dynamics.com/" },
+                { inputString: "http://coveo.crm.dynamics.com?a", expectedUrl: "http://coveo.crm.dynamics.com/" },
+                { inputString: "http://coveo.crm.dynamics.com?a=2", expectedUrl: "http://coveo.crm.dynamics.com/?a=2" },
+                { inputString: "http://coveo.crm.dynamics.com?a=2&b=patate", expectedUrl: "http://coveo.crm.dynamics.com/?a=2&b=patate" },
+            ].forEach(test => {
+                const url = new Url(test.inputString);
+                expect(url.build()).toBe(test.expectedUrl);
+            });
+        });
+
+        it("should build relative URLs correctly", () => {
+            [
+                { inputString: "a", expectedUrl: "/a" },
+                { inputString: "a/b", expectedUrl: "/a/b" },
+                { inputString: "/a/b", expectedUrl: "/a/b" },
+                { inputString: "/a/b?", expectedUrl: "/a/b" },
+                { inputString: "/a/b?a=2", expectedUrl: "/a/b?a=2" },
+            ].forEach(test => {
+                const url = new Url(test.inputString);
+                expect(url.build().endsWith(test.expectedUrl)).toBeTruthy();
+            });
+        });
+    });
+
+    describe("addPath", () => {
+        const anUrl = "http://coveo.com"
+
+        it("should add path added to url", () => {
+            [
+                { path: "a", expectedUrl: `${anUrl}/a` },
+                { path: "a/b", expectedUrl: `${anUrl}/a/b` },
+            ].forEach(test => {
+                const url = new Url(anUrl);
+                url.addPath(test.path)
+                expect(url.build()).toBe(test.expectedUrl);
+            });
+        });
+    });
+});

--- a/tests/odata/OData.spec.ts
+++ b/tests/odata/OData.spec.ts
@@ -1,0 +1,22 @@
+import { OData } from "../../src/Index";
+
+describe("OData", () => {
+    const anEndpoint = "http://coveo.ca";
+    const aResource = "aaa";
+    const anotherResource = "bbb";
+
+    describe("resource", () => {
+        it("should append resources to the resulting query", () => {
+            const odata = new OData({
+                endpoint: anEndpoint,
+                headers: []
+            });
+
+            expect(odata.buildQuery()).toBe(`${anEndpoint}/`);
+            odata.resource(aResource);
+            expect(odata.buildQuery()).toBe(`${anEndpoint}/${aResource}`);
+            odata.resource(anotherResource);
+            expect(odata.buildQuery()).toBe(`${anEndpoint}/${aResource}/${anotherResource}`);
+        });
+    });
+});


### PR DESCRIPTION
With this PR, you don't have to specify the path to be called when initializing the OData request.

You can now do:

`myOData.resource("accounts")`

to call `[baseEndpoint]/accounts`

you can add as many of them as you wish. Ex:

``myOData.resource("api").resource("data").resource("v9.0").resource("accounts")``

to call `[baseEndpoint]/api/data/v9.0/accounts`